### PR TITLE
The collection details api returns field with name 'training_status'

### DIFF
--- a/train-tips.md
+++ b/train-tips.md
@@ -40,7 +40,7 @@ Example response:
 
 ```json
 {
-  "training": {
+  "training_status": {
     "total_examples": 54,
     "available": true,
     "processing": false,


### PR DESCRIPTION
…not 'training' as documented incorrectly in multiple places in docs.