### PR TITLE
Note that `count` param has a default value

### DIFF
--- a/query-aggregations.md
+++ b/query-aggregations.md
@@ -33,6 +33,8 @@ term(enriched_text.concepts.text,count:10)
 ```
 {: codeblock}
 
+**Note:** The `count` parameter has a default value of 10.
+
 ## filter
 {: #filter}
 


### PR DESCRIPTION
I wound up experiencing a frustrating bug because I wrongly assumed that, if you didn't set `count`, you could have unlimited values in the response.